### PR TITLE
小数点切り上げの修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
                 case 'multiply':
                     return decimalPointCalculate(f1.multiply(f2), decimalPoint)
                 case 'mod':
-                    // return decimalPointCalculate(f1.divide(f2), decimalPoint)
-                    return decimalPointCalculate(f1.multiply(f2), decimalPoint)
+                    return decimalPointCalculate(f1.divide(f2), decimalPoint)
+                    // return decimalPointCalculate(f1.multiply(f2), decimalPoint)
                 case 'square':
                     return decimalPointCalculate(f1.multiply(f1), decimalPoint)
                 default :

--- a/index.html
+++ b/index.html
@@ -41,8 +41,8 @@
         }
         function decimalPointCalculate(value, decimalPoint){
             if(decimalPoint === 'ceil'){
-                // return value.ceil()
-                return value.floor()
+                return value.ceil()
+                // return value.floor()
             }
             if(decimalPoint === 'floor'){
                 return value.floor()


### PR DESCRIPTION
小数点切り上げを選択して計算すると切り下げになってしまうバグを修正しました

## 変更後の振る舞い
* 計算結果0.1になるような計算をしたら0.1になる

## 変更前の振る舞い
* 計算結果0.1になるような計算をしたら0になる
